### PR TITLE
Add SpaceActivityPublisher to have the activity of space creation

### DIFF
--- a/war/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/war/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -19,6 +19,13 @@
   <component>
     <key>org.exoplatform.social.core.space.spi.SpaceService</key>
     <type>org.exoplatform.addons.spacesadministration.SpaceServiceImpl</type>
+    <component-plugins>
+      <component-plugin>
+        <name>SpaceActivityPublisher</name>
+        <set-method>addSpaceListener</set-method>
+        <type>org.exoplatform.social.core.application.SpaceActivityPublisher</type>
+      </component-plugin>
+    </component-plugins>
   </component>
 
   <external-component-plugins>


### PR DESCRIPTION
Problem:
- When creating a space, there isn't any activity for that event.
  As consequence, there isn't any activity or comment when this space is updated: renamed, description updated, members updated.

Fix description:
- Register SpaceActivityPublisher to addSpaceListener.
